### PR TITLE
feat(members): move QDyanbing from contributors to team for Ant Design

### DIFF
--- a/app/constant/members.ts
+++ b/app/constant/members.ts
@@ -95,7 +95,8 @@ export const openSourceMembers: OpenSourceMembersType = {
         team: ['skyfeiz'],
     },
     'Ant Design': {
-        contributors: ['984507092', 'QDyanbing', 'broBinChen'],
+        team: ['QDyanbing'],
+        contributors: ['984507092', 'broBinChen'],
     },
     'Ant Design Mobile': {
         contributors: ['984507092'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Ant Design open-source membership listing to reflect QDyanbing’s team membership.
  * Existing contributor listings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->